### PR TITLE
The /photo endpoint now captures a photo from the camera and redirects to it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'sinatra'
+gem 'sinatra-basicauth'
 
 group :development do
   gem 'shotgun'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,8 @@ GEM
       rack (~> 1.3, >= 1.3.6)
       rack-protection (~> 1.2)
       tilt (~> 1.3, >= 1.3.3)
+    sinatra-basicauth (0.0.1)
+      rack
     tilt (1.3.3)
 
 PLATFORMS
@@ -18,3 +20,4 @@ PLATFORMS
 DEPENDENCIES
   shotgun
   sinatra
+  sinatra-basicauth

--- a/server/app.rb
+++ b/server/app.rb
@@ -1,23 +1,44 @@
 #!/usr/bin/env ruby
 
 require 'bundler'
-require 'sinatra/base'
+require 'sinatra'
+require 'sinatra-basicauth'
 require './server/lib/download'
 
 module PrintMe
   class App < Sinatra::Base
     LOCK_FILE = 'printing.lock'
 
-    use Rack::Auth::Basic, "Restricted Area" do |username, password|
-      [username, password] == ['hubot', 'isalive']
+    ## Config
+    set :static, true
+
+    basic_auth do
+      realm "The 3rd Dimension"
+      username 'hubot'
+      password 'isalive'
     end
 
+    ## Routes/Public
     get '/' do
       status 200
       "make_me version F.U-bro"
     end
 
+    get '/photo' do
+      imagesnap = File.join(File.dirname(__FILE__), '..', 'vendor', 'imagesnap', 'imagesnap')
+      rd, wr = IO.pipe
+      pid = Process.spawn(imagesnap, '-', :out  => wr)
+      wr.close
+
+      image = rd.read
+      Process.wait(pid)
+      content_type 'image/jpeg'
+      image
+    end
+
+    ## Routes/Authed
     post '/print' do
+      require_basic_auth
       if File.exist?(LOCK_FILE)
         reason = File.open(LOCK_FILE, 'r') { |f| f.read }
         halt 423, reason
@@ -41,6 +62,7 @@ module PrintMe
     end
 
     get '/lock' do
+      require_basic_auth
       if File.exist?(LOCK_FILE)
         status 423
         File.open(LOCK_FILE, 'r') { |f| f.read }
@@ -51,21 +73,10 @@ module PrintMe
     end
 
     post '/unlock' do
+      require_basic_auth
       File.delete(LOCK_FILE) if File.exist?(LOCK_FILE)
       status 200
       "Lock cleared!"
-    end
-
-    get '/photo' do
-      imagesnap = File.join(File.dirname(__FILE__), '..', 'vendor', 'imagesnap', 'imagesnap')
-      rd, wr = IO.pipe
-      pid = Process.spawn(imagesnap, '-', :out  => wr)
-      wr.close
-
-      image = rd.read
-      Process.wait(pid)
-      content_type 'image/jpeg'
-      image
     end
   end
 end

--- a/server/app.rb
+++ b/server/app.rb
@@ -26,14 +26,13 @@ module PrintMe
 
     get '/photo' do
       imagesnap = File.join(File.dirname(__FILE__), '..', 'vendor', 'imagesnap', 'imagesnap')
-      rd, wr = IO.pipe
-      pid = Process.spawn(imagesnap, '-', :out  => wr)
-      wr.close
 
-      image = rd.read
-      Process.wait(pid)
-      content_type 'image/jpeg'
-      image
+      out_name = 'snap_' + Time.now.to_i.to_s + ".jpg"
+      out_dir = File.join(File.dirname(__FILE__), "public")
+
+      Process.wait Process.spawn(imagesnap, File.join(out_dir, out_name))
+
+      redirect out_name
     end
 
     ## Routes/Authed

--- a/server/public/.gitignore
+++ b/server/public/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
The HTTP auth got refactored out into gem use, the / and /photo paths are no longer auth'd, and the /photo route redirects to the photo it writes to disk with the timestamp.
