### PR TITLE
redirect to STL from thingiverse thing URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'http://rubygems.org'
 
 gem 'sinatra'
 gem 'sinatra-basicauth'
+gem 'nokogiri'
 
 group :development do
   gem 'shotgun'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    nokogiri (1.5.5)
     rack (1.4.1)
     rack-protection (1.2.0)
       rack
@@ -18,6 +19,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  nokogiri
   shotgun
   sinatra
   sinatra-basicauth

--- a/server/lib/download.rb
+++ b/server/lib/download.rb
@@ -1,4 +1,5 @@
 require_relative 'open-uri'
+require 'nokogiri'
 
 module PrintMe
   class Download
@@ -23,6 +24,12 @@ module PrintMe
       if md = url.match(%r{tinkercad\.com/things/(\w+)-[^/]+/$})
         thing_id = md[1]
         url = "https://tinkercad.com/things/#{thing_id}/polysoup.stl"
+      elsif md = url.match(%r{thingiverse\.com/thing:\d+$})
+        doc  = Nokogiri::HTML.parse(open(url))
+        stls = doc.search('#thing-files a')
+        if link = stls.first
+          url = 'http://www.thingiverse.com' + link.attribute('href').value
+        end
       end
 
       url

--- a/server/lib/download.rb
+++ b/server/lib/download.rb
@@ -27,7 +27,7 @@ module PrintMe
       elsif md = url.match(%r{thingiverse\.com/thing:\d+$})
         doc  = Nokogiri::HTML.parse(open(url))
         stls = doc.search('#thing-files a')
-        if link = stls.first
+        if stls.length == 1 && link = stls.first
           url = 'http://www.thingiverse.com' + link.attribute('href').value
         end
       end


### PR DESCRIPTION
In the vein of https://github.com/github/make_me/pull/7, this will redirect to the STL from a regular Thingiverse 'thing' URL.

It's not as easy or simple as the Tinkercad stuff because the IDs don't match (because a Thing can actually be multiple STLs). The page has to be downloaded and parsed, then the first STL link is taken.

:cyclone: 
