### PR TITLE
Don't let just rm dictate the return code of a recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ ifneq ($(words $(MAKECMDGOALS)), 1)
 endif
 	@[[ -c /dev/$(USB) ]] || { echo "No USB device found"; exit 1; }
 	@echo "Printing"
-	(                                     \
-		$(PRINT) $(realpath $^) &         \
-		echo $$1 > $(ROOT)/tmp/print.pid; \
-		wait `cat $(ROOT)/tmp/print.pid`; \
-		rm $(ROOT)/tmp/print.pid;         \
+	(                                       \
+		$(PRINT) $(realpath $^) &           \
+		echo $$1 > $(ROOT)/tmp/print.pid;   \
+		wait `cat $(ROOT)/tmp/print.pid` && \
+		rm $(ROOT)/tmp/print.pid;           \
 	)
 
 
@@ -31,7 +31,7 @@ endif
 		cd vendor/Miracle-Grue/;                                                                     \
 		$(GRUE) -s /dev/null -e /dev/null -o "$(realpath $(dir $@))/$(notdir $@)" "$(realpath $^)" & \
 		echo $$1 > $(ROOT)/tmp/slice.pid;                                                            \
-		wait `cat $(ROOT)/tmp/slice.pid`;                                                            \
+		wait `cat $(ROOT)/tmp/slice.pid` &&                                                          \
 		rm $(ROOT)/tmp/slice.pid;                                                                    \
 	)
 


### PR DESCRIPTION
The last step of the pid writing recipes should not dictate the return code of the block.

Replacing `;` with `&&` before the pid `rm`s so that a failed process will leave behind the pid and exit with a nonzero status
