### PR TITLE
STL Normalization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "vendor/Miracle-Grue"]
 	path = vendor/Miracle-Grue
 	url = https://github.com/skalnik/Miracle-Grue.git
+[submodule "vendor/stltwalker"]
+	path = vendor/stltwalker
+	url = https://github.com/sshirokov/stltwalker.git

--- a/server/app.rb
+++ b/server/app.rb
@@ -10,6 +10,7 @@ module PrintMe
     LOCK_FILE = File.join('tmp', 'printing.lock')
     PID_FILE  = File.join('tmp', 'make.pid')
     LOG_FILE  = File.join('tmp', 'make.log')
+    FETCH_MODEL_FILE = File.join('data', 'fetch.stl')
     CURRENT_MODEL_FILE = File.join('data', 'print.stl')
 
     ## Config
@@ -96,13 +97,20 @@ module PrintMe
 
       stl_url  = params[:url]
       stl_file = CURRENT_MODEL_FILE
-      PrintMe::Download.new(stl_url, stl_file).fetch
+      PrintMe::Download.new(stl_url, FETCH_MODEL_FILE).fetch
+
+      ## Normalize the download
+      normalize = ['./vendor/stltwalker/stltwalker', '-p', '-o', stl_file, FETCH_MODEL_FILE]
+      pid = Process.spawn(*normalize, :err => :out, :out => [LOG_FILE, "w"])
+      _pid, status = Process.wait2 pid
+      halt 409, "Model normalize failed."  unless status.exitstatus == 0
+
       makefile = File.join(File.dirname(__FILE__), '..', 'Makefile')
       make_stl = [ "make", "#{File.dirname(stl_file)}/#{File.basename(stl_file, '.stl')};",
                    "rm #{PID_FILE}"].join(" ")
 
       begin
-        pid = Process.spawn(make_stl, :err => :out, :out => LOG_FILE)
+        pid = Process.spawn(make_stl, :err => :out, :out => [LOG_FILE, "a"])
         File.open(PID_FILE, 'w') { |f| f.write pid }
         Timeout::timeout(5) do
           Process.wait pid

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -3,6 +3,12 @@
 all: | brews
 	$(MAKE) grue
 	$(MAKE) s3g
+	$(MAKE) stltwalker
+
+## stltwalker build
+stltwalker: stltwalker/stltwalker
+stltwalker/stltwalker:
+	make -C stltwalker
 
 ## Grue build
 grue: Miracle-Grue/bin/miracle_grue


### PR DESCRIPTION
This passes incoming STL files through [sshirokov/stltwalker](https://github.com/sshirokov/stltwalker) which parses the STL files, centers then on the build platform and makes sure they are not suspended in the air. 

It also converts all of the inputs to a binary STL file that our slicer won't explode on, such as binary STL files with a poorly chosen header. 

This also adds an easy place to hook in printing N of a thing, as the stltwalker step is done in "packing" mode which means any additional inputs on the command line will be added in a row on the build platform.

cc/ @skalnik 
