### PR TITLE
Grue can generate optional supports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ ROOT = $(shell pwd)
 USB ?= $(shell ls /dev/ | grep tty.usbmodem | head -1)
 
 ## Apps
-GRUE ?= bin/miracle_grue
+GRUE ?= $(ROOT)/vendor/Miracle-Grue/bin/miracle_grue
+GRUE_CONFIG ?= default
 PRINT ?= $(ROOT)/bin/print_gcode -m "The Replicator 2" -p /dev/$(USB) -f
 
 ## What are we making?
@@ -28,8 +29,8 @@ endif
 %.gcode: %.stl
 	@echo "Building gcode: At[$@] In[$^]"
 	(                                                                                                \
-		cd vendor/Miracle-Grue/;                                                                     \
-		$(GRUE) -s /dev/null -e /dev/null -o "$(realpath $(dir $@))/$(notdir $@)" "$(realpath $^)" & \
+		$(GRUE) -s /dev/null -e /dev/null -c $(ROOT)/config/grue-$(GRUE_CONFIG).config               \
+				-o "$(realpath $(dir $@))/$(notdir $@)" "$(realpath $^)" &                           \
 		echo $$! > $(ROOT)/tmp/slice.pid;                                                            \
 		wait `cat $(ROOT)/tmp/slice.pid`;                                                            \
 		rm $(ROOT)/tmp/slice.pid;                                                                    \

--- a/config/grue-default.config
+++ b/config/grue-default.config
@@ -1,0 +1,97 @@
+ {
+    "infillDensity" : 0.1,  // unit: ratio to solid
+    "numberOfShells" : 2, //Number of shells to print
+    "insetDistanceMultiplier" : 1.05,  // unit: layerW // how far apart are insets from each other
+    "roofLayerCount" : 5,  // nb of extra solid layers for roofs 
+    "floorLayerCount" : 5, // nb of extra solid layers for floor
+    "layerWidthRatio" : 1.67,  //Width over height ratio
+    "preCoarseness" : 0.1, //coarseness before all processing
+    "coarseness" : 0.05, // moves shorter than this are combined
+    "directionWeight" : 0.5, 
+    "gridSpacingMultiplier" : 0.85, 
+    
+    "doOutlines" : false, 
+    "doInfills" : true,
+    "doInsets" : true, 
+
+    "doGraphOptimization" : true,  // do we want to apply our graph optimization?
+    "iterativeEffort" : 999, // max number of iterations to run after graph, sanity check only
+      
+    //how fast to move when not extruding
+    "rapidMoveFeedRateXY" : 120, // mm/sec
+    "rapidMoveFeedRateZ" : 23, //mm/sec
+      
+    "doRaft" : false,
+    "raftLayers" : 3, // nb of raft layers (optional)
+    "raftBaseThickness" : 0.5, // thickness of first raft layer
+    "raftInterfaceThickness" : 0.25, // thickness of other raft layers
+    "raftOutset" : 6,  // distance to outset rafts
+    "raftModelSpacing" : 0.1, // distance between topmost raft and bottom of model
+    "raftDensity" : 0.23,
+
+    "doSupport" : false, //whether or not to build support structures
+    "supportMargin" : 2.0, //distance between sides of object and the beginning of support: mm
+    "supportDensity" : 0.095,
+
+    "bedZOffset" : 0.0, //Height to start printing the first layer
+    "layerHeight" : 0.27,  //Height of a layer
+
+    //assumed starting position after header gcode is done
+    "startX" : -110.4,
+    "startY" : -74.0,
+    "startZ" : 0.2,
+
+    "startGcode" : "default://start_replicator_dual.gcode", // gcode to insert at beginning of output
+    "endGcode" : "default://end_replicator_dual.gcode", // gcode to insert at end of output
+    
+    "doPrintProgress" : true, // display % complete on bot
+    
+    "doFanCommand" : true, 
+    "fanLayer" : 5, 
+
+    "defaultExtruder" : 0,
+
+    "extruderProfiles" : [ //configuration values for each extruder
+      {"firstLayerExtrusionProfile": "firstlayer",  //extrusion profile for the first layer
+       "insetsExtrusionProfile" :  "insets", //extrusion profile for the perimeters and insets
+       "infillsExtrusionProfile" : "infill",  //extrusion profile for infill
+       "outlinesExtrusionProfile" : "outlines",  //extrusion profile for outlines
+       "feedDiameter" : 1.82, //diameter in mm of feedstock
+       "nozzleDiameter": 0.4,
+       "retractDistance" : 1, // mm 
+       "retractRate" : 20, // mm/sec
+       "restartExtraDistance" : 0.0 // mm
+      },
+      {"firstLayerExtrusionProfile" : "firstlayer",  //extrusion profile for the first layer
+       "insetsExtrusionProfile" :  "insets", //extrusion profile for the perimeters and insets
+       "infillsExtrusionProfile" : "infill",  //extrusion profile for infill
+       "outlinesExtrusionProfile" : "outlines",  //extrusion profile for outlines
+       "feedDiameter" : 1.82, //diameter in mm of feedstock
+       "nozzleDiameter": 0.4, // mm
+       "retractDistance" : 1, // mm 
+       "retractRate" : 20, //mm/sec
+       "restartExtraDistance" : 0.0 // mm
+      }
+   ],
+   "extrusionProfiles": { // altered extrusion values for different situations, referenced by the extruder
+        "insets": {
+	    "temperature" : 220.0,  //temperature in C
+            "feedrate": 80 // mm/sec feedrate while extruding
+        },
+        "infill": {
+	    "temperature" : 220.0,  //temperature in C
+            "feedrate": 80 //mm/sec
+        },
+        "firstlayer": {
+	    "temperature" : 220.0,  //temperature in C
+            "feedrate": 50 //mm/sec
+        },
+        "outlines": {
+	    "temperature" : 220.0,  //temperature in C
+            "feedrate": 50 //mm/sec
+        }
+    }
+}
+
+
+

--- a/config/grue-support.config
+++ b/config/grue-support.config
@@ -1,0 +1,94 @@
+ {
+    "infillDensity" : 0.1,  // unit: ratio to solid
+    "numberOfShells" : 2, //Number of shells to print
+    "insetDistanceMultiplier" : 1.05,  // unit: layerW // how far apart are insets from each other
+    "roofLayerCount" : 5,  // nb of extra solid layers for roofs
+    "floorLayerCount" : 5, // nb of extra solid layers for floor
+    "layerWidthRatio" : 1.67,  //Width over height ratio
+    "preCoarseness" : 0.1, //coarseness before all processing
+    "coarseness" : 0.05, // moves shorter than this are combined
+    "directionWeight" : 0.5,
+    "gridSpacingMultiplier" : 0.85,
+
+    "doOutlines" : false,
+    "doInfills" : true,
+    "doInsets" : true,
+
+    "doGraphOptimization" : true,  // do we want to apply our graph optimization?
+    "iterativeEffort" : 999, // max number of iterations to run after graph, sanity check only
+
+    //how fast to move when not extruding
+    "rapidMoveFeedRateXY" : 120, // mm/sec
+    "rapidMoveFeedRateZ" : 23, //mm/sec
+
+    "doRaft" : false,
+    "raftLayers" : 3, // nb of raft layers (optional)
+    "raftBaseThickness" : 0.5, // thickness of first raft layer
+    "raftInterfaceThickness" : 0.25, // thickness of other raft layers
+    "raftOutset" : 6,  // distance to outset rafts
+    "raftModelSpacing" : 0.1, // distance between topmost raft and bottom of model
+    "raftDensity" : 0.23,
+
+    "doSupport" : true, //whether or not to build support structures
+    "supportMargin" : 2.0, //distance between sides of object and the beginning of support: mm
+    "supportDensity" : 0.095,
+
+    "bedZOffset" : 0.0, //Height to start printing the first layer
+    "layerHeight" : 0.27,  //Height of a layer
+
+    //assumed starting position after header gcode is done
+    "startX" : -110.4,
+    "startY" : -74.0,
+    "startZ" : 0.2,
+
+    "startGcode" : "default://start_replicator_dual.gcode", // gcode to insert at beginning of output
+    "endGcode" : "default://end_replicator_dual.gcode", // gcode to insert at end of output
+
+    "doPrintProgress" : true, // display % complete on bot
+
+    "doFanCommand" : true,
+    "fanLayer" : 5,
+
+    "defaultExtruder" : 0,
+
+    "extruderProfiles" : [ //configuration values for each extruder
+      {"firstLayerExtrusionProfile": "firstlayer",  //extrusion profile for the first layer
+       "insetsExtrusionProfile" :  "insets", //extrusion profile for the perimeters and insets
+       "infillsExtrusionProfile" : "infill",  //extrusion profile for infill
+       "outlinesExtrusionProfile" : "outlines",  //extrusion profile for outlines
+       "feedDiameter" : 1.82, //diameter in mm of feedstock
+       "nozzleDiameter": 0.4,
+       "retractDistance" : 1, // mm
+       "retractRate" : 20, // mm/sec
+       "restartExtraDistance" : 0.0 // mm
+      },
+      {"firstLayerExtrusionProfile" : "firstlayer",  //extrusion profile for the first layer
+       "insetsExtrusionProfile" :  "insets", //extrusion profile for the perimeters and insets
+       "infillsExtrusionProfile" : "infill",  //extrusion profile for infill
+       "outlinesExtrusionProfile" : "outlines",  //extrusion profile for outlines
+       "feedDiameter" : 1.82, //diameter in mm of feedstock
+       "nozzleDiameter": 0.4, // mm
+       "retractDistance" : 1, // mm
+       "retractRate" : 20, //mm/sec
+       "restartExtraDistance" : 0.0 // mm
+      }
+   ],
+   "extrusionProfiles": { // altered extrusion values for different situations, referenced by the extruder
+        "insets": {
+	    "temperature" : 220.0,  //temperature in C
+            "feedrate": 80 // mm/sec feedrate while extruding
+        },
+        "infill": {
+	    "temperature" : 220.0,  //temperature in C
+            "feedrate": 80 //mm/sec
+        },
+        "firstlayer": {
+	    "temperature" : 220.0,  //temperature in C
+            "feedrate": 50 //mm/sec
+        },
+        "outlines": {
+	    "temperature" : 220.0,  //temperature in C
+            "feedrate": 50 //mm/sec
+        }
+    }
+}


### PR DESCRIPTION
- One with supports enabled and one with them off
- The Makefile is altered with a GRUE_CONFIG var

A config can be selected as follows 

``` bash
$ make GRUE_CONFIG=support data/model
```

The default config, named `default` is the config we've been using up until now,
the second config in this PR is a config that enables support generation during the slice.
