### PR TITLE
Allow passing a `count=N` parameter to print multiple of one thing

### DIFF
--- a/server/app.rb
+++ b/server/app.rb
@@ -73,11 +73,18 @@ module PrintMe
       end
 
       stl_url  = params[:url]
+      count    = (params[:count] || 1).to_i
       stl_file = CURRENT_MODEL_FILE
       PrintMe::Download.new(stl_url, FETCH_MODEL_FILE).fetch
 
+      inputs = []
+      count.times {
+        inputs.push FETCH_MODEL_FILE
+      }
+
       ## Normalize the download
-      normalize = ['./vendor/stltwalker/stltwalker', '-p', '-o', stl_file, FETCH_MODEL_FILE]
+      normalize = ['./vendor/stltwalker/stltwalker', '-p', '-o', stl_file, *inputs]
+      puts "Normalize stirng: #{normalize.inspect}"
       pid = Process.spawn(*normalize, :err => :out, :out => [LOG_FILE, "w"])
       _pid, status = Process.wait2 pid
       halt 409, "Model normalize failed."  unless status.exitstatus == 0


### PR DESCRIPTION
This just adds more of the input parameter to `stltwalker` which puts then into the same object according to it's packing rules.

The packing rule right now is just to line them up on the X axis, but that can be improved without altering this flow.
