### PR TITLE
Allow one to pass a different grue config to print with

### DIFF
--- a/server/app.rb
+++ b/server/app.rb
@@ -74,6 +74,7 @@ module PrintMe
 
       stl_url  = params[:url]
       count    = (params[:count] || 1).to_i
+      grue_conf = (params[:config] || 'default')
       stl_file = CURRENT_MODEL_FILE
       PrintMe::Download.new(stl_url, FETCH_MODEL_FILE).fetch
 
@@ -84,13 +85,13 @@ module PrintMe
 
       ## Normalize the download
       normalize = ['./vendor/stltwalker/stltwalker', '-p', '-o', stl_file, *inputs]
-      puts "Normalize stirng: #{normalize.inspect}"
       pid = Process.spawn(*normalize, :err => :out, :out => [LOG_FILE, "w"])
       _pid, status = Process.wait2 pid
       halt 409, "Model normalize failed."  unless status.exitstatus == 0
 
+      make_params = "GRUE_CONFIG=#{grue_conf}"
       makefile = File.join(File.dirname(__FILE__), '..', 'Makefile')
-      make_stl = [ "make", "#{File.dirname(stl_file)}/#{File.basename(stl_file, '.stl')};",
+      make_stl = [ "make", make_params, "#{File.dirname(stl_file)}/#{File.basename(stl_file, '.stl')};",
                    "rm #{PID_FILE}"].join(" ")
 
       begin


### PR DESCRIPTION
Mainly so that the 'support' config can be loaded and supports should, in theory, be generated by miracle-grue.

The config is specified with the `config` parameter on the /print POST
