### PR TITLE
Support for varying quality prints in the makefile and app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ USB ?= $(shell ls /dev/ | grep tty.usbmodem | head -1)
 ## Apps
 GRUE ?= $(ROOT)/vendor/Miracle-Grue/bin/miracle_grue
 GRUE_CONFIG ?= default
+QUALITY ?= medium
 PRINT ?= $(ROOT)/bin/print_gcode -m "The Replicator 2" -p /dev/$(USB) -f
 
 ## What are we making?
@@ -29,7 +30,19 @@ endif
 %.gcode: %.stl
 	@echo "Building gcode: At[$@] In[$^]"
 	(                                                                                                \
+		LH=0.27;                                                                                     \
+		if [[ "$(QUALITY)" == "high" ]]; then                                                        \
+                LH=0.1;                                                                              \
+		fi;                                                                                          \
+		if [[ "$(QUALITY)" == "medium" ]]; then                                                      \
+                LH=0.27;                                                                             \
+		fi;                                                                                          \
+		if [[ "$(QUALITY)" == "low" ]]; then                                                         \
+                LH=0.34;                                                                             \
+		fi;                                                                                          \
+		echo "Slicing with "$(QUALITY)" quality. Line height: $$LH";                                 \
 		$(GRUE) -s /dev/null -e /dev/null -c $(ROOT)/config/grue-$(GRUE_CONFIG).config               \
+				-h "$$LH"                                                                            \
 				-o "$(realpath $(dir $@))/$(notdir $@)" "$(realpath $^)" &                           \
 		echo $$! > $(ROOT)/tmp/slice.pid;                                                            \
 		wait `cat $(ROOT)/tmp/slice.pid`;                                                            \

--- a/server/app.rb
+++ b/server/app.rb
@@ -75,6 +75,7 @@ module PrintMe
       stl_url  = params[:url]
       count    = (params[:count] || 1).to_i
       grue_conf = (params[:config] || 'default')
+      slice_quality = (params[:quality] || 'medium')
       stl_file = CURRENT_MODEL_FILE
       PrintMe::Download.new(stl_url, FETCH_MODEL_FILE).fetch
 
@@ -89,9 +90,9 @@ module PrintMe
       _pid, status = Process.wait2 pid
       halt 409, "Model normalize failed."  unless status.exitstatus == 0
 
-      make_params = "GRUE_CONFIG=#{grue_conf}"
+      make_params = ["GRUE_CONFIG=#{grue_conf}", "QUALITY=#{slice_quality}"]
       makefile = File.join(File.dirname(__FILE__), '..', 'Makefile')
-      make_stl = [ "make", make_params, "#{File.dirname(stl_file)}/#{File.basename(stl_file, '.stl')};",
+      make_stl = [ "make", *make_params, "#{File.dirname(stl_file)}/#{File.basename(stl_file, '.stl')};",
                    "rm #{PID_FILE}"].join(" ")
 
       begin


### PR DESCRIPTION
Supports "low", "medium" and "high" quality for line hights of 100, 270 and 340 microns.

Defaults to 'medium' quality, and uses it if it does not recognize the input.
