### PR TITLE
Allow density to be specified externally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ USB ?= $(shell ls /dev/ | grep tty.usbmodem | head -1)
 GRUE ?= $(ROOT)/vendor/Miracle-Grue/bin/miracle_grue
 GRUE_CONFIG ?= default
 QUALITY ?= medium
+DENSITY ?= 0.05
 PRINT ?= $(ROOT)/bin/print_gcode -m "The Replicator 2" -p /dev/$(USB) -f
 
 ## What are we making?
@@ -29,7 +30,7 @@ endif
 
 %.gcode: %.stl
 	@echo "Building gcode: At[$@] In[$^]"
-	(                                                                                                \
+	@(                                                                                               \
 		LH=0.27;                                                                                     \
 		if [[ "$(QUALITY)" == "high" ]]; then                                                        \
                 LH=0.1;                                                                              \
@@ -40,9 +41,10 @@ endif
 		if [[ "$(QUALITY)" == "low" ]]; then                                                         \
                 LH=0.34;                                                                             \
 		fi;                                                                                          \
+		                                                                                             \
 		echo "Slicing with "$(QUALITY)" quality. Line height: $$LH";                                 \
 		$(GRUE) -s /dev/null -e /dev/null -c $(ROOT)/config/grue-$(GRUE_CONFIG).config               \
-				-h "$$LH"                                                                            \
+				-h "$$LH" -p $(DENSITY)                                                              \
 				-o "$(realpath $(dir $@))/$(notdir $@)" "$(realpath $^)" &                           \
 		echo $$! > $(ROOT)/tmp/slice.pid;                                                            \
 		wait `cat $(ROOT)/tmp/slice.pid`;                                                            \

--- a/server/app.rb
+++ b/server/app.rb
@@ -76,6 +76,7 @@ module PrintMe
       count    = (params[:count] || 1).to_i
       grue_conf = (params[:config] || 'default')
       slice_quality = (params[:quality] || 'medium')
+      density = (params[:density] || 0.05).to_f
       stl_file = CURRENT_MODEL_FILE
       PrintMe::Download.new(stl_url, FETCH_MODEL_FILE).fetch
 
@@ -90,7 +91,7 @@ module PrintMe
       _pid, status = Process.wait2 pid
       halt 409, "Model normalize failed."  unless status.exitstatus == 0
 
-      make_params = ["GRUE_CONFIG=#{grue_conf}", "QUALITY=#{slice_quality}"]
+      make_params = ["GRUE_CONFIG=#{grue_conf}", "QUALITY=#{slice_quality}", "DENSITY=#{density}"]
       makefile = File.join(File.dirname(__FILE__), '..', 'Makefile')
       make_stl = [ "make", *make_params, "#{File.dirname(stl_file)}/#{File.basename(stl_file, '.stl')};",
                    "rm #{PID_FILE}"].join(" ")


### PR DESCRIPTION
Density or 'infill density' can now be specified by the `density` parameter in the `/print` POST request. 

The default setting is 0.05
