### PR TITLE
Allow printing different objects at once

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'curb'
 gem 'sinatra'
 gem 'sinatra-basicauth'
 gem 'unicorn'
+gem 'activesupport', :require => 'active_support/core_ext'
 
 group :development do
   gem 'shotgun'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,13 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    activesupport (3.2.9)
+      i18n (~> 0.6)
+      multi_json (~> 1.0)
     curb (0.8.3)
+    i18n (0.6.1)
     kgio (2.7.4)
+    multi_json (1.5.0)
     rack (1.4.1)
     rack-protection (1.2.0)
       rack
@@ -25,6 +30,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   curb
   shotgun
   sinatra

--- a/server/app.rb
+++ b/server/app.rb
@@ -3,6 +3,8 @@
 require 'bundler'
 Bundler.require
 require 'timeout'
+require 'active_support/core_ext'
+require 'json'
 require_relative 'lib/download'
 
 module PrintMe
@@ -72,20 +74,32 @@ module PrintMe
         lock!
       end
 
-      stl_url  = params[:url]
-      count    = (params[:count] || 1).to_i
-      grue_conf = (params[:config] || 'default')
-      slice_quality = (params[:quality] || 'medium')
-      density = (params[:density] || 0.05).to_f
-      stl_file = CURRENT_MODEL_FILE
-      PrintMe::Download.new(stl_url, FETCH_MODEL_FILE).fetch
+      # Either parse a JSON body or use params[]
+      # as usual, using the unified `args' hash
+      # from here out
+      begin
+        jparams = JSON.parse(request.body.read).symbolize_keys
+      rescue
+      end
+      args = jparams || params
 
+      stl_url  = [*args[:url]]
+      count    = (args[:count] || 1).to_i
+      grue_conf = (args[:config] || 'default')
+      slice_quality = (args[:quality] || 'medium')
+      density = (args[:density] || 0.05).to_f
+
+      ## Fetch all of the inputs
+      ## to temp files
       inputs = []
-      count.times {
-        inputs.push FETCH_MODEL_FILE
+      stl_url.each_with_index { |url, idx|
+        stl_fetch = FETCH_MODEL_FILE + ".#{idx}"
+        PrintMe::Download.new(url, stl_fetch).fetch
+        inputs.push stl_fetch
       }
 
       ## Normalize the download
+      stl_file = CURRENT_MODEL_FILE
       normalize = ['./vendor/stltwalker/stltwalker', '-p', '-o', stl_file, *inputs]
       pid = Process.spawn(*normalize, :err => :out, :out => [LOG_FILE, "w"])
       _pid, status = Process.wait2 pid


### PR DESCRIPTION
This also supports JSON post bodies

Multiple URLs are supplied as a list to `url` in JSON, or as url[]=...&url[]... urlencoded POST arguments.
