### PR TITLE
Enable the delete method and method override for the lock

### DIFF
--- a/server/app.rb
+++ b/server/app.rb
@@ -16,6 +16,7 @@ module PrintMe
 
     ## Config
     set :static, true
+    enable :method_override
 
     basic_auth do
       realm 'The 3rd Dimension'

--- a/server/app/lock.rb
+++ b/server/app/lock.rb
@@ -15,7 +15,7 @@ module PrintMe
       end
     end
 
-    post '/unlock' do
+    delete '/lock' do
       require_basic_auth
       # If process is still running, don't allow an unlock
       if locked? && !File.exist?(PID_FILE)


### PR DESCRIPTION
This addresses #14 and ensures that the issue of the DELETE method is an upstream problem, while posting with `_method=DELETE` can be used as a workaround.

cc/ @skalnik 
