### PR TITLE
Replacing JSON with Yajl, and removing active support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem 'curb'
 gem 'sinatra'
 gem 'sinatra-basicauth'
 gem 'unicorn'
-gem 'activesupport', :require => 'active_support/core_ext'
 gem 'yajl-ruby', :require => "yajl"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,8 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.9)
-      i18n (~> 0.6)
-      multi_json (~> 1.0)
     curb (0.8.3)
-    i18n (0.6.1)
     kgio (2.7.4)
-    multi_json (1.5.0)
     rack (1.4.1)
     rack-protection (1.2.0)
       rack
@@ -31,7 +26,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
   curb
   shotgun
   sinatra

--- a/server/app.rb
+++ b/server/app.rb
@@ -3,8 +3,6 @@
 require 'bundler'
 Bundler.require
 require 'timeout'
-require 'active_support/core_ext'
-require 'json'
 require_relative 'lib/download'
 
 module PrintMe
@@ -79,7 +77,7 @@ module PrintMe
       # as usual, using the unified `args' hash
       # from here out
       begin
-        jparams = JSON.parse(request.body.read).symbolize_keys
+        jparams = Yajl::Parser.new(:symbolize_keys => true).parse request.body.read
       rescue
       end
       args = jparams || params


### PR DESCRIPTION
It was a series of patches resulting in a resolution.

This removes the vestigial JSON parse and the reliance on AS for `symbolize_keys`
