### PR TITLE
Bounds checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ Then you can POST a URL to the server and it'll start printing. The default
 HTTP auth credentials are *hubot* **:** *isalive*. They can be controlled with the
 `MAKE_ME_USERNAME` and `MAKE_ME_PASSWORD` environment variables.
 
+The maximum deminsions of the print can be specified with the `$MAKE_ME_MAX_X`, `$MAKE_ME_MAX_Y` and
+`$MAKE_ME_MAX_Z` enviornment variables. The defaults are configured for the MakerBot Replicator 2.
+
+
     $ curl -i http://hubot:isalive@localhost:9393/print               \
            -d '{"url": "http://www.thingiverse.com/download:108313"}'
 

--- a/server/app.rb
+++ b/server/app.rb
@@ -104,7 +104,11 @@ module PrintMe
       }
 
       ## Normalize the download
-      bounds = {:L => 285, :W => 153, :H => 155}
+      bounds = {
+        :L => (ENV['MAKE_ME_MAX_X'] || 285).to_f,
+        :W => (ENV['MAKE_ME_MAX_Y'] || 153).to_f,
+        :H => (ENV['MAKE_ME_MAX_Z'] || 155).to_f,
+      }
       stl_file = CURRENT_MODEL_FILE
       normalize = ['./vendor/stltwalker/stltwalker', '-p', '-L', bounds[:L].to_s, '-W', bounds[:W].to_s, '-H', bounds[:H].to_s, '-o', stl_file, "--scale=#{scale}", *inputs]
       pid = Process.spawn(*normalize, :err => :out, :out => [LOG_FILE, "w"])

--- a/server/app.rb
+++ b/server/app.rb
@@ -105,9 +105,9 @@ module PrintMe
 
       ## Normalize the download
       bounds = {
-        :L => (ENV['MAKE_ME_MAX_X'] || 285).to_s,
-        :W => (ENV['MAKE_ME_MAX_Y'] || 153).to_s,
-        :H => (ENV['MAKE_ME_MAX_Z'] || 155).to_s,
+        :L => (ENV['MAKE_ME_MAX_X'] || 285).to_f.to_s,
+        :W => (ENV['MAKE_ME_MAX_Y'] || 153).to_f.to_s,
+        :H => (ENV['MAKE_ME_MAX_Z'] || 155).to_f.to_s,
       }
       stl_file = CURRENT_MODEL_FILE
       normalize = ['./vendor/stltwalker/stltwalker', '-p', '-L', bounds[:L], '-W', bounds[:W], '-H', bounds[:H], '-o', stl_file, "--scale=#{scale}", *inputs]

--- a/server/app.rb
+++ b/server/app.rb
@@ -105,12 +105,12 @@ module PrintMe
 
       ## Normalize the download
       bounds = {
-        :L => (ENV['MAKE_ME_MAX_X'] || 285).to_f,
-        :W => (ENV['MAKE_ME_MAX_Y'] || 153).to_f,
-        :H => (ENV['MAKE_ME_MAX_Z'] || 155).to_f,
+        :L => (ENV['MAKE_ME_MAX_X'] || 285).to_s,
+        :W => (ENV['MAKE_ME_MAX_Y'] || 153).to_s,
+        :H => (ENV['MAKE_ME_MAX_Z'] || 155).to_s,
       }
       stl_file = CURRENT_MODEL_FILE
-      normalize = ['./vendor/stltwalker/stltwalker', '-p', '-L', bounds[:L].to_s, '-W', bounds[:W].to_s, '-H', bounds[:H].to_s, '-o', stl_file, "--scale=#{scale}", *inputs]
+      normalize = ['./vendor/stltwalker/stltwalker', '-p', '-L', bounds[:L], '-W', bounds[:W], '-H', bounds[:H], '-o', stl_file, "--scale=#{scale}", *inputs]
       pid = Process.spawn(*normalize, :err => :out, :out => [LOG_FILE, "w"])
       _pid, status = Process.wait2 pid
       halt 409, "Model normalize failed."  unless status.exitstatus == 0

--- a/server/app.rb
+++ b/server/app.rb
@@ -104,8 +104,9 @@ module PrintMe
       }
 
       ## Normalize the download
+      bounds = {:L => 285, :W => 153, :H => 155}
       stl_file = CURRENT_MODEL_FILE
-      normalize = ['./vendor/stltwalker/stltwalker', '-p', '-o', stl_file, "--scale=#{scale}", *inputs]
+      normalize = ['./vendor/stltwalker/stltwalker', '-p', '-L', bounds[:L].to_s, '-W', bounds[:W].to_s, '-H', bounds[:H].to_s, '-o', stl_file, "--scale=#{scale}", *inputs]
       pid = Process.spawn(*normalize, :err => :out, :out => [LOG_FILE, "w"])
       _pid, status = Process.wait2 pid
       halt 409, "Model normalize failed."  unless status.exitstatus == 0

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -6,9 +6,8 @@ all: | brews
 	$(MAKE) stltwalker
 
 ## stltwalker build
-stltwalker: stltwalker/stltwalker
-stltwalker/stltwalker:
-	make -C stltwalker
+stltwalker:
+	@make -C stltwalker
 
 ## Grue build
 grue: Miracle-Grue/bin/miracle_grue


### PR DESCRIPTION
This pull request introduces bounds checking to the prints.

The default bounds are configured from the Replicator 2 printer and are set at 28.5 x 15.3 x 15.5 cm

A failed bounds check will fail the "Normalization" step of the print.

cc/ @skalnik 

This changes the same lines as your test branch :(
