### PR TITLE
Up Unicorn Timeout

### DIFF
--- a/server/config/unicorn.rb
+++ b/server/config/unicorn.rb
@@ -1,3 +1,3 @@
 worker_processes 3
-timeout 30
+timeout 90
 listen 9292


### PR DESCRIPTION
Ups the unicorn worker timeout to 90 seconds, for those large STL files.
