### PR TITLE
Fix curl flag to follow redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can also use external models from places like
 [Thingiverse](http://www.thingiverse.com):
 
     # Download Mr.Jaws from http://www.thingiverse.com/thing:14702
-    $ curl -F http://www.thingiverse.com/download:48479 > data/jaws.stl
+    $ curl -L http://www.thingiverse.com/download:48479 > data/jaws.stl
 
 Plug the MakerBot printer into the computer with the USB cable.
 


### PR DESCRIPTION
This is totally super minor, but it looks like at least on my version of curl the `-F` flag is for form params or something. I think we need `-L` to follow redirects instead.

Here's my curl version incase it's just broken for me:

```
curl 7.24.0 (x86_64-apple-darwin12.0) libcurl/7.24.0 OpenSSL/0.9.8r zlib/1.2.5
```
