### PR TITLE
WIP: Add Miracle Grue Configurator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ USB ?= $(shell ls /dev/ | grep tty.usbmodem | head -1)
 ## Apps
 GRUE ?= $(ROOT)/vendor/Miracle-Grue/bin/miracle_grue
 GRUE_CONFIG ?= default
-QUALITY ?= medium
-DENSITY ?= 0.05
 PRINT ?= $(ROOT)/bin/print_gcode -m "The Replicator 2" -p /dev/$(USB) -f
 
 ## What are we making?
@@ -31,20 +29,7 @@ endif
 %.gcode: %.stl
 	@echo "Building gcode: At[$@] In[$^]"
 	@(                                                                                               \
-		LH=0.27;                                                                                     \
-		if [[ "$(QUALITY)" == "high" ]]; then                                                        \
-                LH=0.1;                                                                              \
-		fi;                                                                                          \
-		if [[ "$(QUALITY)" == "medium" ]]; then                                                      \
-                LH=0.27;                                                                             \
-		fi;                                                                                          \
-		if [[ "$(QUALITY)" == "low" ]]; then                                                         \
-                LH=0.34;                                                                             \
-		fi;                                                                                          \
-		                                                                                             \
-		echo "Slicing with "$(QUALITY)" quality. Line height: $$LH";                                 \
 		$(GRUE) -s /dev/null -e /dev/null -c $(ROOT)/config/grue-$(GRUE_CONFIG).config               \
-				-h "$$LH" -p $(DENSITY)                                                              \
 				-o "$(realpath $(dir $@))/$(notdir $@)" "$(realpath $^)" &                           \
 		echo $$! > $(ROOT)/tmp/slice.pid;                                                            \
 		wait `cat $(ROOT)/tmp/slice.pid` &&                                                          \

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ make-me can adjust print parameters for you:
     $ make GRUE_CONFIG=default path/to/model
 
 `GRUE_CONFIG=name` controls the slicer config to use. These are stored in
-`./config/` in the project root and two configs are included.
+`./config/` in the project root and three configs are included.
 
 * `default` - The default configuration, it's used if no config is specified.
 * `support` - A slicer configuration that generates support structures

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ line height of object layers.
 
     "infillDensity" : 0.05,
 
-`DENSITY=<percentage>` controls the infill percentage of the print. The default
+`infillDensity` controls the infill percentage of the print. The default
 setting is `0.05`
 
 ### Normalization and packing

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ extension:
 
     $ make data/jaws
 
-This is enough to get most things printed without tweaking, but
-make-me can adjust print parameters for you:
+This is enough to get most things printed without tweaking, you can [tweak
+the configuration](#slicer-config) to your liking to get a more fine-tuned print.
 
 ### Normalization and packing
 

--- a/README.md
+++ b/README.md
@@ -118,8 +118,11 @@ you might enjoy it.
                    "count": 1,                                            \
                    "scale": 1.0,                                          \
                    "quality": "low",                                      \
-                   "density": 0.05,                                       \
-                   "config": "default"}'                                  \
+				   "slicer_args": {                                       \
+                     "infillDensity": 0.20,                               \
+                     "numberOfShells": 5                                  \
+                   }                                                      \
+                  }'                                                      \
            http://hubot:isalive@localhost:9393/print
 
 The parameters in the JSON object are
@@ -128,8 +131,8 @@ The parameters in the JSON object are
 * `quality` - The quality of the print, defined by line height. Can be "high", "medium" or "low". Default: "medium", **Optional**
 * `count`   - The number of times to print all the given objects. Default: 1, **Optional**
 * `scale`   - The scaling factor of the print. Default 1.0, **Optional**
-* `density` - The infill density of the object. From 0.0 to 1.0. Default: 0.05, **Optional**
 * `config`  - The Miracle-Grue config to use during slicing Default: "default", **Optional**
+* `slicer_args` - JSON args to be merged into the slicer config. **Optional**
 
 Returns `HTTP 200 OK` when the print appears to have begun successfully.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ extension:
 This is enough to get most things printed without tweaking, but
 make-me can adjust print parameters for you:
 
-### Slicer config
+## Slicer config
 
     $ make GRUE_CONFIG=default path/to/model
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ for the model. This is particularly awesome for abstract shapes.
 * `raft`    - A configuration that prints the model on a "raft" or
 supporting surface for the model to rest on.
 
-You can copy any of those configs and modify the settings within then to tune
+You can copy any of those configs and modify the settings within them to tune
 your command line prints.
 
 Some settings of interest are:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ extension:
 This is enough to get most things printed without tweaking, but
 make-me can adjust print parameters for you:
 
+### Normalization and packing
+
+Make-me ships with
+[stltwalker](https://github.com/sshirokov/stltwalker), which is used to normalize
+input models and offer advanced functionality. But, stltwalker can also be used
+standalone as part of a manual print.
+
+Help for the version of `stltwalker` bundled with make-me can be found
+at:
+
+    $ vendor/stltwalker/stltwalker -h
+
+Stltwalker can be used to composite multiple objects or multiple copies of a
+single object into a single print:
+
+    $ vendor/stltwalker/stltwalker -p data/object_a.stl data/object_b.stl data/object_b.stl -o data/out.stl
+    # [.. stltwalker output ..]
+    $ make QUALITY=low data/out
+
 ## Slicer config
 
     $ make GRUE_CONFIG=default path/to/model
@@ -80,25 +99,6 @@ line height of object layers.
 
 `infillDensity` controls the infill percentage of the print. The default
 setting is `0.05`
-
-### Normalization and packing
-
-Make-me ships with
-[stltwalker](https://github.com/sshirokov/stltwalker), which is used to normalize
-input models and offer advanced functionality. But, stltwalker can also be used
-standalone as part of a manual print.
-
-Help for the version of `stltwalker` bundled with make-me can be found
-at:
-
-    $ vendor/stltwalker/stltwalker -h
-
-Stltwalker can be used to composite multiple objects or multiple copies of a
-single object into a single print:
-
-    $ vendor/stltwalker/stltwalker -p data/object_a.stl data/object_b.stl data/object_b.stl -o data/out.stl
-    # [.. stltwalker output ..]
-    $ make QUALITY=low data/out
 
 ## HTTP API
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MakeMe [![Build Status](https://travis-ci.org/make-me/make-me.png)](https://travis-ci.org/make-me/make-me)
-A pipeline for taking your [MakerBot Replicator 2](https://store.makerbot.com/replicator2.html) 
+A pipeline for taking your [MakerBot Replicator 2](https://store.makerbot.com/replicator2.html)
 to the next level of awesome. Embrace the meatspace!
 
 ## Support
@@ -7,7 +7,7 @@ to the next level of awesome. Embrace the meatspace!
 At the moment, this only works on **OS X 10.8+** and ships with a binary
 compiled for this platform. However, the binary relates to make-me's
 photo function, so some customization should enable other systems.
- 
+
 [Homebrew](http://mxcl.github.com/homebrew/) is required for the
 bootstrap to run. If you don't have it, go get it. We'll still be here.
 
@@ -23,7 +23,7 @@ as...
 ## CLI Interface
 
 Your printer can now be operated using make-me's command line tools.
-Hooray! Make-me comes with some STL files so you can test the basic 
+Hooray! Make-me comes with some STL files so you can test the basic
 operations of the toolchain:
 
     $ ls ./data
@@ -55,12 +55,19 @@ make-me can adjust print parameters for you:
 * `default` - The default configuration, it's used if no config is specified.
 * `support` - A slicer configuration that generates support structures
 for the model. This is particularly awesome for abstract shapes.
+* `raft`    - A configuration that prints the model on a "raft" or
+supporting surface for the model to rest on.
+
+You can copy any of those configs and modify the settings within then to tune
+your command line prints.
+
+Some settings of interest are:
 
 ### Print quality
 
-    $ make QUALITY=low path/to/model
+    "layerHeight": 0.27,
 
-`QUALITY=(low|medium|high)` controls the quality of the print by altering the
+`layerHeight` controls the quality of the print by altering the
 line height of object layers.
 
 * high   -- 0.1mm
@@ -69,7 +76,7 @@ line height of object layers.
 
 ### Print density
 
-    $ make DENSITY=0.1 path/to/model
+    "infillDensity" : 0.05,
 
 `DENSITY=<percentage>` controls the infill percentage of the print. The default
 setting is `0.05`
@@ -78,7 +85,7 @@ setting is `0.05`
 
 Make-me ships with
 [stltwalker](https://github.com/sshirokov/stltwalker), which is used to normalize
-input models and offer advanced functionality. But, stltwalker can also be used 
+input models and offer advanced functionality. But, stltwalker can also be used
 standalone as part of a manual print.
 
 Help for the version of `stltwalker` bundled with make-me can be found
@@ -186,17 +193,17 @@ Returns `HTTP 404 NOT FOUND` if the lock is free.
 
 [Hubot](http://hubot.github.com/) can now make things for you. If you
 include our
-[hubot-script](https://github.com/github/hubot-scripts/blob/master/src/scripts/make_me.coffee), 
-you'll be able to use your 3D printer through Campfire. Our script 
-comes preconfigured for localhost:9292, but this can be altered for your 
-own network preferences. This may seem like the origins of Skynet, but 
+[hubot-script](https://github.com/github/hubot-scripts/blob/master/src/scripts/make_me.coffee),
+you'll be able to use your 3D printer through Campfire. Our script
+comes preconfigured for localhost:9292, but this can be altered for your
+own network preferences. This may seem like the origins of Skynet, but
 we assure you that it's not.
 
 ## How can I contribute?
 
-Contributing is easy. Fork this repo, hack away, and submit your 
+Contributing is easy. Fork this repo, hack away, and submit your
 [pull request](https://help.github.com/articles/using-pull-requests).
-Make Me is currently maintained by [@skalnik](http://github.com/skalnik/) and 
+Make Me is currently maintained by [@skalnik](http://github.com/skalnik/) and
 [@sshirokov](http://github.com/sshirokov).
 
 Most importantly, go print things! We hope make-me can remove any

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ extension:
 
     $ make data/jaws
 
-This is enough to get most things printed without tweaking, you can [tweak
-the configuration](#slicer-config) to your liking to get a more fine-tuned print.
+This is enough to get most things printed without further tweaking.
 
 ### Normalization and packing
 
@@ -64,7 +63,7 @@ single object into a single print:
     # [.. stltwalker output ..]
     $ make QUALITY=low data/out
 
-## Slicer config
+### Slicer config
 
     $ make GRUE_CONFIG=default path/to/model
 
@@ -79,26 +78,6 @@ supporting surface for the model to rest on.
 
 You can copy any of those configs and modify the settings within them to tune
 your command line prints.
-
-Some settings of interest are:
-
-### Print quality
-
-    "layerHeight": 0.27,
-
-`layerHeight` controls the quality of the print by altering the
-line height of object layers.
-
-* high   -- 0.1mm
-* medium -- 0.27mm
-* low    -- 0.34mm
-
-### Print density
-
-    "infillDensity" : 0.05,
-
-`infillDensity` controls the infill percentage of the print. The default
-setting is `0.05`
 
 ## HTTP API
 

--- a/config/grue-default.config
+++ b/config/grue-default.config
@@ -61,16 +61,6 @@
        "retractDistance" : 1, // mm
        "retractRate" : 20, // mm/sec
        "restartExtraDistance" : 0.0 // mm
-      },
-      {"firstLayerExtrusionProfile" : "firstlayer",  //extrusion profile for the first layer
-       "insetsExtrusionProfile" :  "insets", //extrusion profile for the perimeters and insets
-       "infillsExtrusionProfile" : "infill",  //extrusion profile for infill
-       "outlinesExtrusionProfile" : "outlines",  //extrusion profile for outlines
-       "feedDiameter" : 1.82, //diameter in mm of feedstock
-       "nozzleDiameter": 0.4, // mm
-       "retractDistance" : 1, // mm
-       "retractRate" : 20, //mm/sec
-       "restartExtraDistance" : 0.0 // mm
       }
    ],
    "extrusionProfiles": { // altered extrusion values for different situations, referenced by the extruder

--- a/config/grue-raft.config
+++ b/config/grue-raft.config
@@ -21,7 +21,7 @@
     "rapidMoveFeedRateXY" : 120, // mm/sec
     "rapidMoveFeedRateZ" : 23, //mm/sec
 
-    "doRaft" : true
+    "doRaft" : true,
     "raftLayers" : 3, // nb of raft layers (optional)
     "raftBaseThickness" : 0.5, // thickness of first raft layer
     "raftInterfaceThickness" : 0.25, // thickness of other raft layers

--- a/config/grue-raft.config
+++ b/config/grue-raft.config
@@ -1,0 +1,94 @@
+ {
+    "infillDensity" : 0.05,  // unit: ratio to solid
+    "numberOfShells" : 2, //Number of shells to print
+    "insetDistanceMultiplier" : 1.05,  // unit: layerW // how far apart are insets from each other
+    "roofLayerCount" : 5,  // nb of extra solid layers for roofs
+    "floorLayerCount" : 5, // nb of extra solid layers for floor
+    "layerWidthRatio" : 1.67,  //Width over height ratio
+    "preCoarseness" : 0.1, //coarseness before all processing
+    "coarseness" : 0.05, // moves shorter than this are combined
+    "directionWeight" : 0.5,
+    "gridSpacingMultiplier" : 0.85,
+
+    "doOutlines" : false,
+    "doInfills" : true,
+    "doInsets" : true,
+
+    "doGraphOptimization" : true,  // do we want to apply our graph optimization?
+    "iterativeEffort" : 999, // max number of iterations to run after graph, sanity check only
+
+    //how fast to move when not extruding
+    "rapidMoveFeedRateXY" : 120, // mm/sec
+    "rapidMoveFeedRateZ" : 23, //mm/sec
+
+    "doRaft" : true
+    "raftLayers" : 3, // nb of raft layers (optional)
+    "raftBaseThickness" : 0.5, // thickness of first raft layer
+    "raftInterfaceThickness" : 0.25, // thickness of other raft layers
+    "raftOutset" : 6,  // distance to outset rafts
+    "raftModelSpacing" : 0.1, // distance between topmost raft and bottom of model
+    "raftDensity" : 0.23,
+
+    "doSupport" : false, //whether or not to build support structures
+    "supportMargin" : 2.0, //distance between sides of object and the beginning of support: mm
+    "supportDensity" : 0.095,
+
+    "bedZOffset" : 0.0, //Height to start printing the first layer
+    "layerHeight" : 0.27,  //Height of a layer
+
+    //assumed starting position after header gcode is done
+    "startX" : -110.4,
+    "startY" : -74.0,
+    "startZ" : 0.2,
+
+    "startGcode" : "default://start_replicator_dual.gcode", // gcode to insert at beginning of output
+    "endGcode" : "default://end_replicator_dual.gcode", // gcode to insert at end of output
+
+    "doPrintProgress" : true, // display % complete on bot
+
+    "doFanCommand" : true,
+    "fanLayer" : 5,
+
+    "defaultExtruder" : 0,
+
+    "extruderProfiles" : [ //configuration values for each extruder
+      {"firstLayerExtrusionProfile": "firstlayer",  //extrusion profile for the first layer
+       "insetsExtrusionProfile" :  "insets", //extrusion profile for the perimeters and insets
+       "infillsExtrusionProfile" : "infill",  //extrusion profile for infill
+       "outlinesExtrusionProfile" : "outlines",  //extrusion profile for outlines
+       "feedDiameter" : 1.82, //diameter in mm of feedstock
+       "nozzleDiameter": 0.4,
+       "retractDistance" : 1, // mm
+       "retractRate" : 20, // mm/sec
+       "restartExtraDistance" : 0.0 // mm
+      },
+      {"firstLayerExtrusionProfile" : "firstlayer",  //extrusion profile for the first layer
+       "insetsExtrusionProfile" :  "insets", //extrusion profile for the perimeters and insets
+       "infillsExtrusionProfile" : "infill",  //extrusion profile for infill
+       "outlinesExtrusionProfile" : "outlines",  //extrusion profile for outlines
+       "feedDiameter" : 1.82, //diameter in mm of feedstock
+       "nozzleDiameter": 0.4, // mm
+       "retractDistance" : 1, // mm
+       "retractRate" : 20, //mm/sec
+       "restartExtraDistance" : 0.0 // mm
+      }
+   ],
+   "extrusionProfiles": { // altered extrusion values for different situations, referenced by the extruder
+        "insets": {
+	    "temperature" : 220.0,  //temperature in C
+            "feedrate": 80 // mm/sec feedrate while extruding
+        },
+        "infill": {
+	    "temperature" : 220.0,  //temperature in C
+            "feedrate": 80 //mm/sec
+        },
+        "firstlayer": {
+	    "temperature" : 220.0,  //temperature in C
+            "feedrate": 50 //mm/sec
+        },
+        "outlines": {
+	    "temperature" : 220.0,  //temperature in C
+            "feedrate": 50 //mm/sec
+        }
+    }
+}

--- a/server/app.rb
+++ b/server/app.rb
@@ -98,7 +98,9 @@ module MakeMe
                       0.27
                     end
 
-      slicer_args[:lineHeight] = line_height
+      # Merge slicer_args into the quality array. Anything in slicer_args
+      # overwrites our notion of "quality"
+      slicer_args = {:lineHeight => quality}.merge(slicer_args)
 
       configurator = MakeMe::MiracleGrueConfigurator.new(slicer_args)
       configurator.save(GRUE_CONFIG)

--- a/server/app.rb
+++ b/server/app.rb
@@ -100,7 +100,7 @@ module MakeMe
 
       # Merge slicer_args into the quality array. Anything in slicer_args
       # overwrites our notion of "quality"
-      slicer_args = {:lineHeight => quality}.merge(slicer_args)
+      slicer_args = {:lineHeight => line_height}.merge(slicer_args)
 
       configurator = MakeMe::MiracleGrueConfigurator.new(slicer_args)
       configurator.save(GRUE_CONFIG)

--- a/server/app.rb
+++ b/server/app.rb
@@ -121,7 +121,7 @@ module MakeMe
       end
 
       # Print the normalized STL
-      make_stl    = [ "make", "GRUE_CONFIG=#{GRUE_CONFIG}",
+      make_stl    = [ "make", "GRUE_CONFIG=make-me",
                       "#{File.dirname(output)}/#{File.basename(output, '.stl')};",
                       "rm #{PID_FILE}"].join(" ")
 

--- a/server/app.rb
+++ b/server/app.rb
@@ -121,11 +121,7 @@ module MakeMe
       end
 
       # Print the normalized STL
-      make_params = [ "GRUE_CONFIG=#{grue_conf}",
-                      "QUALITY=#{slice_quality}",
-                      "DENSITY=#{density}"]
-
-      make_stl    = [ "make", *make_params,
+      make_stl    = [ "make", "GRUE_CONFIG=#{GRUE_CONFIG}",
                       "#{File.dirname(output)}/#{File.basename(output, '.stl')};",
                       "rm #{PID_FILE}"].join(" ")
 

--- a/server/app.rb
+++ b/server/app.rb
@@ -79,19 +79,17 @@ module MakeMe
 
       args = Yajl::Parser.new(:symbolize_keys => true).parse(request.body.read) || {}
 
-      stl_urls      = [*args[:url]]
-      count         = args[:count]
-      scale         = args[:scale]
-      supports      = (args[:supports] || false)
-      raft          = (args[:raft]     || false)
-      slice_quality = (args[:quality]  || 'medium')
-      density       = (args[:density]  || 0.05).to_f
+      stl_urls    = [*args[:url]]
+      count       = args[:count]
+      scale       = args[:scale]
+      slicer_args = (args[:slicer_args] || {})
+      quality     = (args[:quality]  || 'medium')
 
       normalizer_args = {}
       normalizer_args[:count] = count if count
       normalizer_args[:scale] = scale if scale
 
-      lineHeight =  case slice_quality
+      line_height = case quality
                     when 'low'
                       0.34
                     when 'high'
@@ -100,14 +98,9 @@ module MakeMe
                       0.27
                     end
 
-      slicerArgs =  {
-                      :infillDensity => density,
-                      :lineHeight    => lineHeight,
-                      :doSupport     => supports,
-                      :doRaft        => raft
-                    }
+      slicer_args[:lineHeight] = line_height
 
-      configurator = MakeMe::MiracleGrueConfigurator.new(slicerArgs)
+      configurator = MakeMe::MiracleGrueConfigurator.new(slicer_args)
       configurator.save(GRUE_CONFIG)
 
       # Fetch all of the inputs to temp files

--- a/server/app.rb
+++ b/server/app.rb
@@ -82,11 +82,10 @@ module MakeMe
       stl_urls      = [*args[:url]]
       count         = args[:count]
       scale         = args[:scale]
-      supports      = args[:supports]
-      raft          = args[:raft]
-      grue_conf     = (args[:config]  || 'default')
-      slice_quality = (args[:quality] || 'medium')
-      density       = (args[:density] || 0.05).to_f
+      supports      = (args[:supports] || false)
+      raft          = (args[:raft]     || false)
+      slice_quality = (args[:quality]  || 'medium')
+      density       = (args[:density]  || 0.05).to_f
 
       normalizer_args = {}
       normalizer_args[:count] = count if count

--- a/server/app.rb
+++ b/server/app.rb
@@ -124,8 +124,8 @@ module MakeMe
                       "#{File.dirname(output)}/#{File.basename(output, '.stl')};",
                       "rm #{PID_FILE}"].join(" ")
 
-      # Kick off the print, if it runs for >5 seconds, it's unlikely it failed
-      # during slicing
+      # Slicing usually is usually under 5 seconds, so if the process runs
+      # longer, it's probably printing correctly
       begin
         pid = Process.spawn(make_stl, :err => :out, :out => [LOG_FILE, "a"])
         File.open(PID_FILE, 'w') { |f| f.write pid }

--- a/server/lib/miracle_grue_configurator.rb
+++ b/server/lib/miracle_grue_configurator.rb
@@ -1,0 +1,98 @@
+module MakeMe
+  class MiracleGrueConfigurator
+    attr_reader :config
+
+    def initialize(config)
+      @config = defaults.merge(config)
+    end
+
+    def save(filename)
+      File.open(filename, 'w') do |file|
+        file.write Yajl::Encoder.encode(config)
+      end
+    end
+
+    def defaults
+      {
+        :infillDensity           => 0.05, # How solid should it be
+        :numberOfShells          => 2,    # Number of shells to print
+        :insetDistanceMultiplier => 1.05, # unit: layerW/how far apart are insets from each other
+        :roofLayerCount          => 5,    # How many solid layers for roofs
+        :floorLayerCount         => 5,    # How many solid layers for floors
+        :layerWidthRatio         => 1.67, # Width over height ratio
+        :preCoarseness           => 0.1,  # Coarseness before all processing
+        :coarseness              => 0.05, # Moves shorter than this are combined
+        :directionWeight         => 0.5,
+        :gridSpacingMultiplier   => 0.85,
+
+        :doOutlines => false,
+        :doInfills  => true,
+        :doInsets   => true,
+
+        :doGraphOptimization => true, # Do we want to apply our graph optimization?
+        :iterativeEffort     => 999,  # Max number of iterations to run after graph,
+                                      # sanity check only
+
+        # how fast to move when not extruding in mm/sec
+        :rapidMoveFeedRateXY => 120,
+        :rapidMoveFeedRateZ  => 23,
+
+        # Rafts
+        :doRaft                 => false,
+        :raftLayers             => 3,    # Number of raft layers to print
+        :raftBaseThickness      => 0.5,  # Thickness of first raft layer
+        :raftInterfaceThickness => 0.25, # Thickness of other raft layers
+        :raftOutset             => 6,    # Distance to outset rafts
+        :raftModelSpacing       => 0.1,  # Distance between top most raft and bottom of model
+        :raftDensity            => 0.23, # Overall density of the raft
+
+        # Supports
+        :doSupport      => false,
+        :supportMargin  => 2.0,   # Distance between sides of object and start of support in mm
+        :supportDensity => 0.095,
+
+        :bedZOffset  => 0.0,  # Height to start printing the first layer
+        :layerHeight => 0.27, # Height of a layer
+
+        # Assumed starting position after header gcode is done
+        :startX => -110.4,
+        :startY => -74.0,
+        :startZ => 0.2,
+
+        # Start and end GCode to send before & after actual print
+        # Default to /dev/null since s3g can send this for us.
+        :startGcode => "/dev/null",
+        :endGcode   => "/dev/null",
+
+        :doPrintProgress => true, # Display % printed
+
+        :doFanCommand => true, # Turn on filament fan
+        :fanLayer     => 5,    # Turn it on after layer 5
+
+        :defaultExtruder => 0,
+        :extruderProfiles => [ # configuration values for our single extruder
+          {
+            :firstLayerExtrusionProfile => "firstlayer",
+            :insetsExtrusionProfile     => "insets",
+            :infillsExtrusionProfile    => "infill",
+            :outlinesExtrusionProfile   => "outlines",
+
+            :feedDiameter         => 1.82, # diameter in mm of feedstock
+            :nozzleDiameter       => 0.4,
+            :retractDistance      => 1,    # mm
+            :retractRate          => 20,   # mm/sec
+            :restartExtraDistance => 0.0   # mm
+          }
+        ],
+        # Different extrusion settings for each profile as defined above
+        # Temperatures in degrees C and feedrate in mm/s
+        :extrusionProfiles => {
+          :insets     => { :temperature => 220.0, :feedrate => 80 },
+          :infill     => { :temperature => 220.0, :feedrate => 80 },
+          :firstlayer => { :temperature => 220.0, :feedrate => 50 },
+          :outlines   => { :temperature => 220.0, :feedrate => 50 }
+        }
+      }
+    end
+  end
+end

--- a/server/lib/miracle_grue_configurator.rb
+++ b/server/lib/miracle_grue_configurator.rb
@@ -8,7 +8,7 @@ module MakeMe
 
     def save(filename)
       File.open(filename, 'w') do |file|
-        file.write Yajl::Encoder.encode(config)
+        file.write Yajl::Encoder.encode(config, :pretty => true)
       end
     end
 

--- a/server/lib/miracle_grue_configurator.rb
+++ b/server/lib/miracle_grue_configurator.rb
@@ -2,7 +2,7 @@ module MakeMe
   class MiracleGrueConfigurator
     attr_reader :config
 
-    def initialize(config)
+    def initialize(config = {})
       @config = defaults.merge(config)
     end
 

--- a/server/lib/miracle_grue_configurator.rb
+++ b/server/lib/miracle_grue_configurator.rb
@@ -13,86 +13,10 @@ module MakeMe
     end
 
     def defaults
-      {
-        :infillDensity           => 0.05, # How solid should it be
-        :numberOfShells          => 2,    # Number of shells to print
-        :insetDistanceMultiplier => 1.05, # unit: layerW/how far apart are insets from each other
-        :roofLayerCount          => 5,    # How many solid layers for roofs
-        :floorLayerCount         => 5,    # How many solid layers for floors
-        :layerWidthRatio         => 1.67, # Width over height ratio
-        :preCoarseness           => 0.1,  # Coarseness before all processing
-        :coarseness              => 0.05, # Moves shorter than this are combined
-        :directionWeight         => 0.5,
-        :gridSpacingMultiplier   => 0.85,
-
-        :doOutlines => false,
-        :doInfills  => true,
-        :doInsets   => true,
-
-        :doGraphOptimization => true, # Do we want to apply our graph optimization?
-        :iterativeEffort     => 999,  # Max number of iterations to run after graph,
-                                      # sanity check only
-
-        # how fast to move when not extruding in mm/sec
-        :rapidMoveFeedRateXY => 120,
-        :rapidMoveFeedRateZ  => 23,
-
-        # Rafts
-        :doRaft                 => false,
-        :raftLayers             => 3,    # Number of raft layers to print
-        :raftBaseThickness      => 0.5,  # Thickness of first raft layer
-        :raftInterfaceThickness => 0.25, # Thickness of other raft layers
-        :raftOutset             => 6,    # Distance to outset rafts
-        :raftModelSpacing       => 0.1,  # Distance between top most raft and bottom of model
-        :raftDensity            => 0.23, # Overall density of the raft
-
-        # Supports
-        :doSupport      => false,
-        :supportMargin  => 2.0,   # Distance between sides of object and start of support in mm
-        :supportDensity => 0.095,
-
-        :bedZOffset  => 0.0,  # Height to start printing the first layer
-        :layerHeight => 0.27, # Height of a layer
-
-        # Assumed starting position after header gcode is done
-        :startX => -110.4,
-        :startY => -74.0,
-        :startZ => 0.2,
-
-        # Start and end GCode to send before & after actual print
-        # Default to /dev/null since s3g can send this for us.
-        :startGcode => "/dev/null",
-        :endGcode   => "/dev/null",
-
-        :doPrintProgress => true, # Display % printed
-
-        :doFanCommand => true, # Turn on filament fan
-        :fanLayer     => 5,    # Turn it on after layer 5
-
-        :defaultExtruder => 0,
-        :extruderProfiles => [ # configuration values for our single extruder
-          {
-            :firstLayerExtrusionProfile => "firstlayer",
-            :insetsExtrusionProfile     => "insets",
-            :infillsExtrusionProfile    => "infill",
-            :outlinesExtrusionProfile   => "outlines",
-
-            :feedDiameter         => 1.82, # diameter in mm of feedstock
-            :nozzleDiameter       => 0.4,
-            :retractDistance      => 1,    # mm
-            :retractRate          => 20,   # mm/sec
-            :restartExtraDistance => 0.0   # mm
-          }
-        ],
-        # Different extrusion settings for each profile as defined above
-        # Temperatures in degrees C and feedrate in mm/s
-        :extrusionProfiles => {
-          :insets     => { :temperature => 220.0, :feedrate => 80 },
-          :infill     => { :temperature => 220.0, :feedrate => 80 },
-          :firstlayer => { :temperature => 220.0, :feedrate => 50 },
-          :outlines   => { :temperature => 220.0, :feedrate => 50 }
-        }
-      }
+      root = File.realpath File.join (File.dirname __FILE__), "..", ".."
+      File.open File.join "config", "grue-default.config" do |defaults|
+        Yajl::Parser.new(:symbolize_keys => true).parse defaults
+      end
     end
   end
 end

--- a/spec/lib/miracle_grue_configurator_spec.rb
+++ b/spec/lib/miracle_grue_configurator_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe MakeMe::MiracleGrueConfigurator do
+  describe 'initialization' do
+    it 'has a sane default from the config' do
+      expect(described_class.new.config[:infillDensity]).to eq(0.05)
+    end
+
+    it 'can overwrite a default' do
+      density = 0.10
+      configurator = described_class.new({:infillDensity => density})
+      expect(configurator.config[:infillDensity]).to eq(density)
+    end
+  end
+end


### PR DESCRIPTION
While wanting to add support for rafts, I saw that we could easily just generate the config for Miracle Grue on the fly with values passed in. This is still a WIP. I'd like to see any settings easily adjustable by just including them in the POST data.
- [x] Tests for MiracleGrueConfigurator
- [x] Support any configuration data being POSTed in
- [x] Update README
- [x] Update Hubot script
