### PR TITLE
Less options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ USB ?= $(shell ls /dev/ | grep tty.usbmodem | head -1)
 ## Apps
 GRUE ?= $(ROOT)/vendor/Miracle-Grue/bin/miracle_grue
 GRUE_CONFIG ?= default
-QUALITY ?= medium
-DENSITY ?= 0.05
 PRINT ?= $(ROOT)/bin/print_gcode -m "The Replicator 2" -p /dev/$(USB) -f
 
 ## What are we making?
@@ -31,20 +29,7 @@ endif
 %.gcode: %.stl
 	@echo "Building gcode: At[$@] In[$^]"
 	@(                                                                                               \
-		LH=0.27;                                                                                     \
-		if [[ "$(QUALITY)" == "high" ]]; then                                                        \
-                LH=0.1;                                                                              \
-		fi;                                                                                          \
-		if [[ "$(QUALITY)" == "medium" ]]; then                                                      \
-                LH=0.27;                                                                             \
-		fi;                                                                                          \
-		if [[ "$(QUALITY)" == "low" ]]; then                                                         \
-                LH=0.34;                                                                             \
-		fi;                                                                                          \
-		                                                                                             \
-		echo "Slicing with "$(QUALITY)" quality. Line height: $$LH";                                 \
 		$(GRUE) -s /dev/null -e /dev/null -c $(ROOT)/config/grue-$(GRUE_CONFIG).config               \
-				-h "$$LH" -p $(DENSITY)                                                              \
 				-o "$(realpath $(dir $@))/$(notdir $@)" "$(realpath $^)" &                           \
 		echo $$! > $(ROOT)/tmp/slice.pid;                                                            \
 		wait `cat $(ROOT)/tmp/slice.pid` &&                                                          \

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ make-me can adjust print parameters for you:
     $ make GRUE_CONFIG=default path/to/model
 
 `GRUE_CONFIG=name` controls the slicer config to use. These are stored in
-`./config/` in the project root and two configs are included.
+`./config/` in the project root and three configs are included.
 
 * `default` - The default configuration, it's used if no config is specified.
 * `support` - A slicer configuration that generates support structures

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ line height of object layers.
 
     "infillDensity" : 0.05,
 
-`DENSITY=<percentage>` controls the infill percentage of the print. The default
+`infillDensity` controls the infill percentage of the print. The default
 setting is `0.05`
 
 ### Normalization and packing

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ extension:
 
     $ make data/jaws
 
-This is enough to get most things printed without tweaking, but
-make-me can adjust print parameters for you:
+This is enough to get most things printed without tweaking, you can [tweak
+the configuration](#slicer-config) to your liking to get a more fine-tuned print.
 
 ### Normalization and packing
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ extension:
 This is enough to get most things printed without tweaking, but
 make-me can adjust print parameters for you:
 
-### Slicer config
+## Slicer config
 
     $ make GRUE_CONFIG=default path/to/model
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ for the model. This is particularly awesome for abstract shapes.
 * `raft`    - A configuration that prints the model on a "raft" or
 supporting surface for the model to rest on.
 
-You can copy any of those configs and modify the settings within then to tune
+You can copy any of those configs and modify the settings within them to tune
 your command line prints.
 
 Some settings of interest are:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ extension:
 This is enough to get most things printed without tweaking, but
 make-me can adjust print parameters for you:
 
+### Normalization and packing
+
+Make-me ships with
+[stltwalker](https://github.com/sshirokov/stltwalker), which is used to normalize
+input models and offer advanced functionality. But, stltwalker can also be used
+standalone as part of a manual print.
+
+Help for the version of `stltwalker` bundled with make-me can be found
+at:
+
+    $ vendor/stltwalker/stltwalker -h
+
+Stltwalker can be used to composite multiple objects or multiple copies of a
+single object into a single print:
+
+    $ vendor/stltwalker/stltwalker -p data/object_a.stl data/object_b.stl data/object_b.stl -o data/out.stl
+    # [.. stltwalker output ..]
+    $ make QUALITY=low data/out
+
 ## Slicer config
 
     $ make GRUE_CONFIG=default path/to/model
@@ -80,25 +99,6 @@ line height of object layers.
 
 `infillDensity` controls the infill percentage of the print. The default
 setting is `0.05`
-
-### Normalization and packing
-
-Make-me ships with
-[stltwalker](https://github.com/sshirokov/stltwalker), which is used to normalize
-input models and offer advanced functionality. But, stltwalker can also be used
-standalone as part of a manual print.
-
-Help for the version of `stltwalker` bundled with make-me can be found
-at:
-
-    $ vendor/stltwalker/stltwalker -h
-
-Stltwalker can be used to composite multiple objects or multiple copies of a
-single object into a single print:
-
-    $ vendor/stltwalker/stltwalker -p data/object_a.stl data/object_b.stl data/object_b.stl -o data/out.stl
-    # [.. stltwalker output ..]
-    $ make QUALITY=low data/out
 
 ## HTTP API
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MakeMe [![Build Status](https://travis-ci.org/make-me/make-me.png)](https://travis-ci.org/make-me/make-me)
-A pipeline for taking your [MakerBot Replicator 2](https://store.makerbot.com/replicator2.html) 
+A pipeline for taking your [MakerBot Replicator 2](https://store.makerbot.com/replicator2.html)
 to the next level of awesome. Embrace the meatspace!
 
 ## Support
@@ -7,7 +7,7 @@ to the next level of awesome. Embrace the meatspace!
 At the moment, this only works on **OS X 10.8+** and ships with a binary
 compiled for this platform. However, the binary relates to make-me's
 photo function, so some customization should enable other systems.
- 
+
 [Homebrew](http://mxcl.github.com/homebrew/) is required for the
 bootstrap to run. If you don't have it, go get it. We'll still be here.
 
@@ -23,7 +23,7 @@ as...
 ## CLI Interface
 
 Your printer can now be operated using make-me's command line tools.
-Hooray! Make-me comes with some STL files so you can test the basic 
+Hooray! Make-me comes with some STL files so you can test the basic
 operations of the toolchain:
 
     $ ls ./data
@@ -55,12 +55,19 @@ make-me can adjust print parameters for you:
 * `default` - The default configuration, it's used if no config is specified.
 * `support` - A slicer configuration that generates support structures
 for the model. This is particularly awesome for abstract shapes.
+* `raft`    - A configuration that prints the model on a "raft" or
+supporting surface for the model to rest on.
+
+You can copy any of those configs and modify the settings within then to tune
+your command line prints.
+
+Some settings of interest are:
 
 ### Print quality
 
-    $ make QUALITY=low path/to/model
+    "layerHeight": 0.27,
 
-`QUALITY=(low|medium|high)` controls the quality of the print by altering the
+`layerHeight` controls the quality of the print by altering the
 line height of object layers.
 
 * high   -- 0.1mm
@@ -69,7 +76,7 @@ line height of object layers.
 
 ### Print density
 
-    $ make DENSITY=0.1 path/to/model
+    "infillDensity" : 0.05,
 
 `DENSITY=<percentage>` controls the infill percentage of the print. The default
 setting is `0.05`
@@ -78,7 +85,7 @@ setting is `0.05`
 
 Make-me ships with
 [stltwalker](https://github.com/sshirokov/stltwalker), which is used to normalize
-input models and offer advanced functionality. But, stltwalker can also be used 
+input models and offer advanced functionality. But, stltwalker can also be used
 standalone as part of a manual print.
 
 Help for the version of `stltwalker` bundled with make-me can be found
@@ -186,17 +193,17 @@ Returns `HTTP 404 NOT FOUND` if the lock is free.
 
 [Hubot](http://hubot.github.com/) can now make things for you. If you
 include our
-[hubot-script](https://github.com/github/hubot-scripts/blob/master/src/scripts/make_me.coffee), 
-you'll be able to use your 3D printer through Campfire. Our script 
-comes preconfigured for localhost:9292, but this can be altered for your 
-own network preferences. This may seem like the origins of Skynet, but 
+[hubot-script](https://github.com/github/hubot-scripts/blob/master/src/scripts/make_me.coffee),
+you'll be able to use your 3D printer through Campfire. Our script
+comes preconfigured for localhost:9292, but this can be altered for your
+own network preferences. This may seem like the origins of Skynet, but
 we assure you that it's not.
 
 ## How can I contribute?
 
-Contributing is easy. Fork this repo, hack away, and submit your 
+Contributing is easy. Fork this repo, hack away, and submit your
 [pull request](https://help.github.com/articles/using-pull-requests).
-Make Me is currently maintained by [@skalnik](http://github.com/skalnik/) and 
+Make Me is currently maintained by [@skalnik](http://github.com/skalnik/) and
 [@sshirokov](http://github.com/sshirokov).
 
 Most importantly, go print things! We hope make-me can remove any

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ extension:
 
     $ make data/jaws
 
-This is enough to get most things printed without tweaking, you can [tweak
-the configuration](#slicer-config) to your liking to get a more fine-tuned print.
+This is enough to get most things printed without further tweaking.
 
 ### Normalization and packing
 
@@ -64,7 +63,7 @@ single object into a single print:
     # [.. stltwalker output ..]
     $ make QUALITY=low data/out
 
-## Slicer config
+### Slicer config
 
     $ make GRUE_CONFIG=default path/to/model
 
@@ -79,26 +78,6 @@ supporting surface for the model to rest on.
 
 You can copy any of those configs and modify the settings within them to tune
 your command line prints.
-
-Some settings of interest are:
-
-### Print quality
-
-    "layerHeight": 0.27,
-
-`layerHeight` controls the quality of the print by altering the
-line height of object layers.
-
-* high   -- 0.1mm
-* medium -- 0.27mm
-* low    -- 0.34mm
-
-### Print density
-
-    "infillDensity" : 0.05,
-
-`infillDensity` controls the infill percentage of the print. The default
-setting is `0.05`
 
 ## HTTP API
 


### PR DESCRIPTION
This removes the `QUALITY` and `DENSITY` options as options from the command line on the strong suspicion that Miracle Grue was ignoring those when the config is specified. 

This updates the README to ask users to edit the config to specify specific options, as the web interface is already doing in #69 

cc/ @skalnik 
### Now with the correct merge target!@
