### PR TITLE
Update print_gcode.py to handle changes in profile and buffer overflow exceptions

### DIFF
--- a/bin/print_gcode.py
+++ b/bin/print_gcode.py
@@ -34,7 +34,7 @@ else:
     port = options.port
 factory = makerbot_driver.MachineFactory()
 obj = factory.build_from_port(port)
-profile = obj.profile()
+profile = getattr(obj, 'profile')
 
 assembler = makerbot_driver.GcodeAssembler(profile)
 start, end, variables = assembler.assemble_recipe()

--- a/bin/print_gcode.py
+++ b/bin/print_gcode.py
@@ -35,7 +35,7 @@ else:
     port = options.port
 factory = makerbot_driver.MachineFactory()
 obj = factory.build_from_port(port)
-profile = getattr(obj, 'profile')
+profile = obj.profile
 
 assembler = makerbot_driver.GcodeAssembler(profile)
 start, end, variables = assembler.assemble_recipe()


### PR DESCRIPTION
The profile is now an attribute on the factory object and no longer a method to be called.

When writing to the USB port the serial library will (likely) generate exceptions that are expected to be handled at higher levels by retrying the write (a form of poor mans polling for write buffer space).
